### PR TITLE
Add Volume Slider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ yarn-error.log*
 .sentryclirc
 
 .swp
+
+*.code-workspace
+.env.d

--- a/src/components/subjects/AudioButton.tsx
+++ b/src/components/subjects/AudioButton.tsx
@@ -12,7 +12,7 @@ import { useAppSelector } from "@store";
 import { ApiSubjectVocabulary, ApiSubjectVocabularyLike, getStoredAudio } from "@api";
 import { getIntegerSetting, sample } from "@utils";
 
-import { globalNotification } from "@global/AntInterface.tsx";
+import { globalMessage, globalNotification } from "@global/AntInterface.tsx";
 
 import { GlobalHotKeys } from "react-hotkeys";
 
@@ -39,13 +39,18 @@ function playSound(
       return;
     }
 
+    if (volume === 0) {
+      globalMessage.warning("Your volume is too low to hear anything!");
+    }
+
     if (audioContext.state === "suspended") {
       debug("playSound: audioContext was suspended! attempting to resume");
       audioContext.resume();
     }
+
     const gainNode = audioContext.createGain();
     gainNode.gain.value = volume / 100;
-    gainNode.connect(audioContext.destination)
+    gainNode.connect(audioContext.destination);
 
     debug("playSound: audioContext state: %s; playing sound (length: %o, duration: %o, volume: %o)", audioContext.state, buffer.length, buffer.duration, gainNode.gain.value);
 
@@ -90,7 +95,7 @@ export function useVocabAudio(
     debug("useVocabAudio.play called %o %s %o %o", subject, pronunciation, finalLoading, finalDisabled);
     if (!subject || finalLoading || finalDisabled) return;
 
-    const audioVolume = getIntegerSetting("audioVolume")
+    const audioVolume = getIntegerSetting("audioVolume");
 
     // If we've already loaded the sounds, play a random one
     if (buffers && savedPronunciation === pronunciation) {

--- a/src/components/subjects/AudioButton.tsx
+++ b/src/components/subjects/AudioButton.tsx
@@ -9,8 +9,8 @@ import classNames from "classnames";
 
 import { useAppSelector } from "@store";
 
-import { ApiSubjectVocabulary, ApiSubjectVocabularyLike, getStoredAudio, useUserLevel } from "@api";
-import { getIntegerSetting, sample, useIntegerSetting } from "@utils";
+import { ApiSubjectVocabulary, ApiSubjectVocabularyLike, getStoredAudio } from "@api";
+import { getIntegerSetting, sample } from "@utils";
 
 import { globalNotification } from "@global/AntInterface.tsx";
 

--- a/src/components/subjects/AudioButton.tsx
+++ b/src/components/subjects/AudioButton.tsx
@@ -10,7 +10,7 @@ import classNames from "classnames";
 import { useAppSelector } from "@store";
 
 import { ApiSubjectVocabulary, ApiSubjectVocabularyLike, getStoredAudio, useUserLevel } from "@api";
-import { sample } from "@utils";
+import { getIntegerSetting, sample, useIntegerSetting } from "@utils";
 
 import { globalNotification } from "@global/AntInterface.tsx";
 
@@ -30,7 +30,8 @@ type VocabAudioHookRes = [
 
 function playSound(
   buffer: AudioBuffer | undefined,
-  setPlaying: Dispatch<SetStateAction<boolean>>
+  setPlaying: Dispatch<SetStateAction<boolean>>,
+  volume: number
 ) {
   try {
     if (!buffer) {
@@ -42,8 +43,11 @@ function playSound(
       debug("playSound: audioContext was suspended! attempting to resume");
       audioContext.resume();
     }
+    const gainNode = audioContext.createGain();
+    gainNode.gain.value = volume / 100;
+    gainNode.connect(audioContext.destination)
 
-    debug("playSound: audioContext state: %s; playing sound (length: %o, duration: %o)", audioContext.state, buffer.length, buffer.duration);
+    debug("playSound: audioContext state: %s; playing sound (length: %o, duration: %o, volume: %o)", audioContext.state, buffer.length, buffer.duration, gainNode.gain.value);
 
     const source = audioContext.createBufferSource();
     source.buffer = buffer;
@@ -53,7 +57,7 @@ function playSound(
       setPlaying(false);
     };
 
-    source.connect(audioContext.destination);
+    source.connect(gainNode);
     source.start();
     setPlaying(true);
   } catch (e: any) {
@@ -86,10 +90,12 @@ export function useVocabAudio(
     debug("useVocabAudio.play called %o %s %o %o", subject, pronunciation, finalLoading, finalDisabled);
     if (!subject || finalLoading || finalDisabled) return;
 
+    const audioVolume = getIntegerSetting("audioVolume")
+
     // If we've already loaded the sounds, play a random one
     if (buffers && savedPronunciation === pronunciation) {
-      debug("useVocabAudio.play: playing saved pronunciation %s: %o", pronunciation, buffers);
-      playSound(sample(buffers), setPlaying);
+      debug("useVocabAudio.play: playing saved pronunciation %s: %o (volume: %o)", pronunciation, buffers, audioVolume);
+      playSound(sample(buffers), setPlaying, audioVolume);
       return;
     }
 
@@ -143,8 +149,8 @@ export function useVocabAudio(
       }
     }
 
-    debug("useVocabAudio.play: now playing fresh sound");
-    playSound(sample(newBuffers), setPlaying);
+    debug("useVocabAudio.play: now playing fresh sound (volume: %o)", audioVolume);
+    playSound(sample(newBuffers), setPlaying, audioVolume);
     setBuffers(newBuffers);
     setSavedPronunciation(pronunciation);
     setLoading(false);

--- a/src/global/theme/wkTheme.ts
+++ b/src/global/theme/wkTheme.ts
@@ -3,6 +3,7 @@
 // Full details: https://github.com/Lemmmy/KanjiSchool/blob/master/LICENSE
 
 import { theme as AntTheme, ThemeConfig } from "antd";
+import { blue } from "@ant-design/colors";
 import { CSSProperties, useMemo } from "react";
 import { convertKeyName } from "@global/theme/themeUtil.ts";
 
@@ -39,6 +40,12 @@ const BASE_THEME: Partial<ThemeConfig> = {
     Menu: {
       activeBarBorderWidth: 0,
       itemMarginBlock: 0
+    },
+    Slider: {
+      trackBg: blue[6],
+      trackHoverBg: blue[5],
+      handleColor: blue[6],
+      colorPrimaryBorderHover: blue[5] // handle hover color
     }
   }
 };
@@ -59,7 +66,6 @@ const THEME_LIGHT: WkTheme = {
         colorBgSpotlight: "#f0f0f0",
         colorTextLightSolid: globalToken.colorText
       },
-
       Divider: {
         colorSplit: "rgba(0, 0, 0, 0.15)"
       }

--- a/src/layout/nav/AppHeader.tsx
+++ b/src/layout/nav/AppHeader.tsx
@@ -24,7 +24,7 @@ const gitVersion: string = import.meta.env.VITE_GIT_VERSION;
 export const headerElementClass = classNames(
   "flex-0 h-header py-0 px-[20px] flex items-center justify-center",
   "border-0 border-l border-solid border-l-white/10 light:border-l-split",
-  "bg-transparent transition-colors hover:bg-white/5 light:hover:bg-black/5 cursor-pointer"
+  "bg-transparent transition-colors hover:bg-white/5 light:hover:bg-black/5 cursor-pointer select-none"
 );
 
 export const dropdownOverlayClass = classNames(

--- a/src/layout/nav/AppHeader.tsx
+++ b/src/layout/nav/AppHeader.tsx
@@ -13,7 +13,7 @@ import { ConditionalLink } from "@comp/ConditionalLink";
 import { OnlineStatus } from "./OnlineStatus";
 import { SyncProgressBars } from "./progress";
 import { ItemsDropdown } from "./ItemsDropdown";
-import { MuteButton } from "./MuteButton.tsx";
+import { VolumePopover } from "./VolumePopover.tsx";
 import { Search } from "./search/Search";
 import { UserInfo } from "./UserInfo";
 import { TopMenu } from "./TopMenu";
@@ -67,7 +67,7 @@ export function AppHeader(): JSX.Element | null {
     <div className="flex-1" />
 
     {/* Mute */}
-    <MuteButton />
+    <VolumePopover />
 
     {/* Non-mobile stuff */}
     {sm && <>

--- a/src/layout/nav/MuteButton.tsx
+++ b/src/layout/nav/MuteButton.tsx
@@ -2,19 +2,32 @@
 // This file is part of KanjiSchool under AGPL-3.0.
 // Full details: https://github.com/Lemmmy/KanjiSchool/blob/master/LICENSE
 
-import { Tooltip, Slider, Popover } from "antd";
+import { useCallback, useMemo } from "react";
+import { Popover, PopoverProps, Slider, Tooltip } from "antd";
+import { SliderTooltipProps } from "antd/es/slider";
+import { PlayCircleOutlined, SoundOutlined } from "@ant-design/icons";
+import classNames from "classnames";
 
 import { useAppSelector } from "@store";
+import { setIntegerSetting, toggleBooleanSetting, useBooleanSetting, useIntegerSetting } from "@utils";
 
-import { setBooleanSetting, setIntegerSetting, useBooleanSetting, useIntegerSetting } from "@utils";
+import { debounce } from "lodash-es";
 import { ConditionalLink } from "@comp/ConditionalLink.tsx";
-import { PlayCircleOutlined, SoundOutlined } from "@ant-design/icons";
 
 import { headerElementClass } from "./AppHeader.tsx";
+
+// Allow clicking too so the volume popover can be opened on mobile
+const popoverTriggers: PopoverProps["trigger"] = ["hover", "click"];
+
+const sliderTooltipProps: SliderTooltipProps = {
+  placement: "left",
+  formatter: value => value ? `${value.toFixed(0)}%` : "0%",
+};
 
 export function MuteButton(): JSX.Element {
   const audioMuted = useBooleanSetting("audioMuted");
   const audioVolume = useIntegerSetting("audioVolume");
+  const setVolume = useCallback((value: number) => setIntegerSetting("audioVolume", value, false), []);
 
   function MenuIcon(): JSX.Element {
     if (audioVolume === 0) {
@@ -26,48 +39,60 @@ export function MuteButton(): JSX.Element {
     }
   }
 
-  function toggleAutoPlay() {
-    setBooleanSetting("audioMuted", !audioMuted, false);
-  }
+  const content = <div className="flex flex-col gap-2 h-full items-center justify-items-center select-none">
+    <div className="text-sm mb-1">Volume</div>
 
-  function setVolume(value: number) {
-    setIntegerSetting("audioVolume", value, false);
-  }
+    {/* Volume slider */}
+    <Slider
+      className="h-[20vh] md:h-24"
+      vertical
+      tooltip={sliderTooltipProps}
+      defaultValue={audioVolume}
+      onChangeComplete={setVolume}
+    />
 
-  const hasAnyAutoplaying = useAppSelector(s => s.settings.audioAutoplayLessons || s.settings.audioAutoplayReviews);
+    {/* Toggle auto-play button */}
+    <AutoPlayControl />
+  </div>;
 
-  function AutoPlayControl(): JSX.Element {
-    if (hasAnyAutoplaying) {
-      return <Tooltip title="Auto-play audio">
-        <div className="flex flex-col items-center justify-center" onClick={toggleAutoPlay}>
-          {audioMuted ? <NoAutoPlayIcon /> : <PlayCircleOutlined />}
-        </div>
-      </Tooltip>;
-    } else {
-      return <Tooltip title="Auto-playing audio is disabled.">
-        <ConditionalLink to="/settings" matchTo>
-          <div className={headerElementClass}>
-            <NoAutoPlayIcon />
-          </div>
-        </ConditionalLink>
-      </Tooltip>;
-    }
-  }
-
-  const menu: JSX.Element =
-    <div className = "h-full items-center justify-items-center" >
-      <div className="flex flex-col items-center justify-center">
-        <Slider vertical defaultValue={audioVolume} onChangeComplete={setVolume} className="h-24" />
-        <p className="m-0">Volume</p>
-      </div>
-      <AutoPlayControl />
-    </div>;
-
-  return <Popover content={menu} >
-    <div className={headerElementClass}> {/* ant-dropdown-link */}
+  return <Popover content={content} trigger={popoverTriggers}>
+    <div className={headerElementClass}>
       <MenuIcon />
     </div>
   </Popover>;
+}
+
+function AutoPlayControl(): JSX.Element {
+  const iconClass = "cursor-pointer mb-1 select-none";
+
+  const audioMuted = useBooleanSetting("audioMuted");
+
+  // Debounce the toggle to work around a bug where antd tooltips cause onClick to fire twice on mobile
+  const toggleAutoPlay = useMemo(
+    () => debounce(() => toggleBooleanSetting("audioMuted", false), 150, { leading: true, trailing: false }),
+    []
+  );
+
+  const hasAnyAutoplaying = useAppSelector(s => s.settings.audioAutoplayLessons || s.settings.audioAutoplayReviews);
+
+  if (hasAnyAutoplaying) {
+    return <Tooltip title="Auto-play audio">
+      <div
+        className="flex flex-col items-center justify-center cursor-pointer select-none"
+        onClick={toggleAutoPlay}
+      >
+        {audioMuted
+          ? <NoAutoPlayIcon className={iconClass} />
+          : <PlayCircleOutlined className={iconClass} />}
+      </div>
+    </Tooltip>;
+  } else {
+    return <Tooltip title="Auto-playing audio is disabled.">
+      <ConditionalLink to="/settings" matchTo>
+        <NoAutoPlayIcon className={iconClass} />
+      </ConditionalLink>
+    </Tooltip>;
+  }
 }
 
 function MuteIcon(): JSX.Element {
@@ -77,8 +102,8 @@ function MuteIcon(): JSX.Element {
   </div>;
 }
 
-function NoAutoPlayIcon(): JSX.Element {
-  return <div className="relative flex items-center justify-center">
+function NoAutoPlayIcon({ className }: { className?: string }): JSX.Element {
+  return <div className={classNames("relative flex items-center justify-center", className)}>
     <PlayCircleOutlined className="text-red/50" />
     <div className="absolute w-[20px] h-[2px] bg-red -rotate-45 rounded-[3px]" />
   </div>;

--- a/src/layout/nav/MuteButton.tsx
+++ b/src/layout/nav/MuteButton.tsx
@@ -8,57 +8,78 @@ import { useAppSelector } from "@store";
 
 import { setBooleanSetting, setIntegerSetting, useBooleanSetting, useIntegerSetting } from "@utils";
 import { ConditionalLink } from "@comp/ConditionalLink.tsx";
-import { SoundOutlined } from "@ant-design/icons";
+import { PlayCircleOutlined, SoundOutlined } from "@ant-design/icons";
 
 import { headerElementClass } from "./AppHeader.tsx";
 
 export function MuteButton(): JSX.Element {
   const audioMuted = useBooleanSetting("audioMuted");
   const audioVolume = useIntegerSetting("audioVolume");
-  
-  function toggleMute() {
+
+  function MenuIcon(): JSX.Element {
+    if (audioVolume === 0) {
+      return <MuteIcon />;
+    } else if (audioMuted) {
+      return <NoAutoPlayIcon />;
+    } else {
+      return <SoundOutlined />;
+    }
+  }
+
+  function toggleAutoPlay() {
     setBooleanSetting("audioMuted", !audioMuted, false);
   }
-  
+
   function setVolume(value: number) {
-    if (value === 0 && !audioMuted) {
-      setBooleanSetting("audioMuted", true, false);
-    } else if (audioMuted && value > 0) {
-      setBooleanSetting("audioMuted", false, false);
-    }
-    setIntegerSetting("audioVolume", value, false)
+    setIntegerSetting("audioVolume", value, false);
   }
 
   const hasAnyAutoplaying = useAppSelector(s => s.settings.audioAutoplayLessons || s.settings.audioAutoplayReviews);
 
-  const menu: JSX.Element = 
+  function AutoPlayControl(): JSX.Element {
+    if (hasAnyAutoplaying) {
+      return <Tooltip title="Auto-play audio">
+        <div className="flex flex-col items-center justify-center" onClick={toggleAutoPlay}>
+          {audioMuted ? <NoAutoPlayIcon /> : <PlayCircleOutlined />}
+        </div>
+      </Tooltip>;
+    } else {
+      return <Tooltip title="Auto-playing audio is disabled.">
+        <ConditionalLink to="/settings" matchTo>
+          <div className={headerElementClass}>
+            <NoAutoPlayIcon />
+          </div>
+        </ConditionalLink>
+      </Tooltip>;
+    }
+  }
+
+  const menu: JSX.Element =
     <div className = "h-full items-center justify-items-center" >
-      <div className="flex flex-col items-center justify-center"><Slider vertical defaultValue={audioVolume} onChangeComplete={setVolume} className="h-24" /><p className="m-0">Volume</p></div>
-      <div className="flex flex-col items-center justify-center" onClick={toggleMute}> {audioMuted ? <MuteIcon /> : <SoundOutlined />} </div>
+      <div className="flex flex-col items-center justify-center">
+        <Slider vertical defaultValue={audioVolume} onChangeComplete={setVolume} className="h-24" />
+        <p className="m-0">Volume</p>
+      </div>
+      <AutoPlayControl />
     </div>;
 
-  if (hasAnyAutoplaying) {
-      return <Popover
-        content={menu}
-      >
-        <div className={headerElementClass}> {/* ant-dropdown-link */}
-          {audioMuted ? <MuteIcon /> : <SoundOutlined />}
-        </div>
-      </Popover>;
-  } else {
-    return <Tooltip title="Audio is disabled.">
-      <ConditionalLink to="/settings" matchTo>
-        <div className={headerElementClass}>
-          <MuteIcon />
-        </div>
-      </ConditionalLink>
-    </Tooltip>;
-  }
+  return <Popover content={menu} >
+    <div className={headerElementClass}> {/* ant-dropdown-link */}
+      <MenuIcon />
+    </div>
+  </Popover>;
 }
 
 function MuteIcon(): JSX.Element {
   return <div className="relative flex items-center justify-center">
     <SoundOutlined className="text-red/50" />
+    <div className="absolute w-[20px] h-[2px] bg-red -rotate-45 rounded-[3px]" />
+  </div>;
+}
+
+function NoAutoPlayIcon(): JSX.Element {
+  return <div className="relative flex items-center justify-center">
+    <PlayCircleOutlined className="text-red/50" />
     <div className="absolute w-[20px] h-[2px] bg-red -rotate-45 rounded-[3px]" />
   </div>;
 }

--- a/src/layout/nav/MuteButton.tsx
+++ b/src/layout/nav/MuteButton.tsx
@@ -2,31 +2,51 @@
 // This file is part of KanjiSchool under AGPL-3.0.
 // Full details: https://github.com/Lemmmy/KanjiSchool/blob/master/LICENSE
 
-import { Tooltip } from "antd";
+import { Tooltip, Slider, Popover } from "antd";
 
 import { useAppSelector } from "@store";
 
-import { headerElementClass } from "@layout/nav/AppHeader.tsx";
-import { setBooleanSetting, useBooleanSetting } from "@utils";
+import { setBooleanSetting, setIntegerSetting, useBooleanSetting, useIntegerSetting } from "@utils";
 import { ConditionalLink } from "@comp/ConditionalLink.tsx";
 import { SoundOutlined } from "@ant-design/icons";
 
+import { headerElementClass } from "./AppHeader.tsx";
+
 export function MuteButton(): JSX.Element {
   const audioMuted = useBooleanSetting("audioMuted");
-  const hasAnyAutoplaying = useAppSelector(s => s.settings.audioAutoplayLessons || s.settings.audioAutoplayReviews);
-
+  const audioVolume = useIntegerSetting("audioVolume");
+  
   function toggleMute() {
     setBooleanSetting("audioMuted", !audioMuted, false);
   }
+  
+  function setVolume(value: number) {
+    if (value === 0 && !audioMuted) {
+      setBooleanSetting("audioMuted", true, false);
+    } else if (audioMuted && value > 0) {
+      setBooleanSetting("audioMuted", false, false);
+    }
+    setIntegerSetting("audioVolume", value, false)
+  }
+
+  const hasAnyAutoplaying = useAppSelector(s => s.settings.audioAutoplayLessons || s.settings.audioAutoplayReviews);
+
+  const menu: JSX.Element = 
+    <div className = "h-full items-center justify-items-center" >
+      <div className="flex flex-col items-center justify-center"><Slider vertical defaultValue={audioVolume} onChangeComplete={setVolume} className="h-24" /><p className="m-0">Volume</p></div>
+      <div className="flex flex-col items-center justify-center" onClick={toggleMute}> {audioMuted ? <MuteIcon /> : <SoundOutlined />} </div>
+    </div>;
 
   if (hasAnyAutoplaying) {
-    return <Tooltip title={audioMuted ? "Unmute auto-playing audio" : "Mute auto-playing audio"}>
-      <div className={headerElementClass} onClick={toggleMute}>
-        {audioMuted ? <MuteIcon /> : <SoundOutlined />}
-      </div>
-    </Tooltip>;
+      return <Popover
+        content={menu}
+      >
+        <div className={headerElementClass}> {/* ant-dropdown-link */}
+          {audioMuted ? <MuteIcon /> : <SoundOutlined />}
+        </div>
+      </Popover>;
   } else {
-    return <Tooltip title="Auto-playing audio is disabled.">
+    return <Tooltip title="Audio is disabled.">
       <ConditionalLink to="/settings" matchTo>
         <div className={headerElementClass}>
           <MuteIcon />

--- a/src/layout/nav/VolumePopover.tsx
+++ b/src/layout/nav/VolumePopover.tsx
@@ -24,7 +24,7 @@ const sliderTooltipProps: SliderTooltipProps = {
   formatter: value => value ? `${value.toFixed(0)}%` : "0%",
 };
 
-export function MuteButton(): JSX.Element {
+export function VolumePopover(): JSX.Element {
   const audioMuted = useBooleanSetting("audioMuted");
   const audioVolume = useIntegerSetting("audioVolume");
   const setVolume = useCallback((value: number) => setIntegerSetting("audioVolume", value, false), []);

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -2,7 +2,7 @@
 // This file is part of KanjiSchool under AGPL-3.0.
 // Full details: https://github.com/Lemmmy/KanjiSchool/blob/master/LICENSE
 
-import { defaultFonts, loadSettings, lsGetNumber, lsGetObject, SettingsState } from "@utils";
+import { defaultFonts, loadSettings, lsGetNumber, lsGetObject, SettingName, SettingsState } from "@utils";
 import { Preset, PresetType } from "@comp/preset-editor";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { PickByValue } from "utility-types";
@@ -48,6 +48,10 @@ const settingsSlice = createSlice({
   reducers: {
     setBooleanSetting(s, { payload }: SetSettingPayloadAction<boolean>) {
       s[payload.settingName] = payload.value;
+    },
+
+    toggleBooleanSetting(s, { payload }: PayloadAction<SettingName<boolean>>) {
+      s[payload] = !s[payload];
     },
 
     setIntegerSetting(s, { payload }: SetSettingPayloadAction<number>) {
@@ -98,6 +102,7 @@ const settingsSlice = createSlice({
 
 export const {
   setBooleanSetting,
+  toggleBooleanSetting,
   setIntegerSetting,
   setStringSetting,
   setHotkeyHelpVisible,

--- a/src/utils/settings/set.ts
+++ b/src/utils/settings/set.ts
@@ -32,6 +32,18 @@ export function setBooleanSetting(
   if (notify) notifySettingChange();
 }
 
+export function toggleBooleanSetting(
+  settingName: SettingName<boolean>,
+  notify = true
+): void {
+  debug("toggling setting [boolean] %s value", settingName);
+
+  store.dispatch(settings.toggleBooleanSetting(settingName));
+  localStorage.setItem(getSettingKey(settingName), store.getState().settings[settingName] ? "true" : "false");
+
+  if (notify) notifySettingChange();
+}
+
 export function setIntegerSetting(
   settingName: SettingName<number>,
   value: number,

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -177,6 +177,8 @@ export interface SettingsStateBase {
   // ===========================================================================
   /** Mute all audio */
   audioMuted: boolean;
+  /** Audio Volume */
+  audioVolume: number;
   /** Autoplay audio in lessons */
   audioAutoplayLessons: boolean;
   /** Autoplay audio in reviews */
@@ -287,6 +289,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   selfStudyWithLessons: false,
 
   audioMuted: false,
+  audioVolume: 100,
   audioAutoplayLessons: true,
   audioAutoplayReviews: true,
   audioFetchMax: 200,

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -175,7 +175,7 @@ export interface SettingsStateBase {
   // ===========================================================================
   // AUDIO SETTINGS
   // ===========================================================================
-  /** Mute all audio */
+  /** Mute all auto-playing audio */
   audioMuted: boolean;
   /** Audio Volume */
   audioVolume: number;


### PR DESCRIPTION
Fixes #24. Adds a volume slider popout, and button beneath to mute:
<img src="https://github.com/user-attachments/assets/56b34519-b95f-4562-b9d4-e39f7b041c86" height=300 alt="Screenshot of the volume slider and mute button">
Additionally, when the volume is set to 0, the `audioMuted` setting gets set to `true`, and when raised from 0 gets set to `false`. File and component names were left untouched, feel free to change at your discretion (`MuteButton` isn't only a mute button anymore for example.)